### PR TITLE
DS9 django1.7 compatible

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3,7 +3,7 @@
 Django-multilingual-DS9 is a branch of django-multilingual, forked from django-multilingual-ng, with restructured core.
 
 ### Requirements: ###
-* Django 1.6
+* Django 1.6 or 1.7
 * Django 1.4 and 1.5 are supported by version 0.4.
 
 Django-multilingual-ds9 does not have to be fully compatible with django-multilingual-ng, but basic features should not

--- a/changelog.markdown
+++ b/changelog.markdown
@@ -6,10 +6,16 @@
 #### 0.4.0 ####
  * Support Django 1.4 and 1.5.
  * Upgrade flatpages.
- * Change in flatpages database structure:
+ * Change in flatpages database structure (PostgreSQL):
 
    ```sql
    ALTER TABLE "multilingual_flatpage_sites" RENAME COLUMN "multilingualflatpage_id" TO "flatpage_id";
+   ```
+
+    OR (MySQL):
+
+   ```sql
+   ALTER TABLE `multilingual_flatpage_sites` CHANGE `multilingualflatpage_id` `flatpage_id` INT;
    ```
 
  * Remove deprecated code from django-multilingual-ng.

--- a/multilingual/models/fields.py
+++ b/multilingual/models/fields.py
@@ -64,7 +64,8 @@ class TranslationRelation(ForeignObject):
     """
     requires_unique_target = False  # This avoids django validation
 
-    def __init__(self, to, base_name, language_code=None, **kwargs):
+    def __init__(self, to, from_fields=None, to_fields=None, base_name=None, language_code=None,
+            related_name=None, on_delete=None, **kwargs):
         self._base_name = base_name
         self._language_code = language_code
 
@@ -83,8 +84,13 @@ class TranslationRelation(ForeignObject):
         kwargs['unique'] = True
         kwargs['null'] = True
 
-        to_fields = ['master']
-        super(TranslationRelation, self).__init__(to, [], to_fields, **kwargs)
+        if from_fields is None:
+            from_fields = []
+        if to_fields is None:
+            to_fields = ['master']
+        super(TranslationRelation, self).__init__(to,
+            from_fields=from_fields,
+            to_fields=to_fields, **kwargs)
 
     def contribute_to_class(self, cls, name, virtual_only=False):
         super(TranslationRelation, self).contribute_to_class(cls, name, virtual_only=virtual_only)

--- a/multilingual/models/query.py
+++ b/multilingual/models/query.py
@@ -11,6 +11,6 @@ class MultilingualQuerySet(QuerySet):
     A specialized QuerySet that knows how to handle translatable
     fields in ordering and filtering methods.
     """
-    def __init__(self, model=None, query=None, using=None):
+    def __init__(self, model=None, query=None, **kwargs):
         query = query or MultilingualQuery(model)
-        super(MultilingualQuerySet, self).__init__(model, query, using)
+        super(MultilingualQuerySet, self).__init__(model, query, **kwargs)

--- a/multilingual/models/sql/query.py
+++ b/multilingual/models/sql/query.py
@@ -21,8 +21,7 @@ class MultilingualQuery(Query):
 
     For proper function we need to take care of JOINs between multilingual and translation tables.
     """
-    def build_filter(self, filter_expr, branch_negated=False, current_negated=False,
-                     can_reuse=None):
+    def build_filter(self, filter_expr, **kwargs):
         """
         Build filters with respect to the multilingual fields.
         """
@@ -33,8 +32,7 @@ class MultilingualQuery(Query):
         new_name = expand_lookup(self.get_meta(), field_name)
         filter_expr = LOOKUP_SEP.join([new_name] + parts[1:]), value
 
-        return super(MultilingualQuery, self).build_filter(filter_expr, branch_negated=branch_negated,
-                                                           current_negated=current_negated, can_reuse=can_reuse)
+        return super(MultilingualQuery, self).build_filter(filter_expr, **kwargs)
 
     def add_fields(self, field_names, allow_m2m=True):
         opts = self.get_meta()


### PR DESCRIPTION
Django 1.7 compatibility fixes:
- Django 1.7 added `hints` argument to a QuerySet constructor
- Django 1.7 introduced built-in migrations, so TranslationRelation received many unexpected arguments while `./manage.py migrate`
